### PR TITLE
Taran adding sorting

### DIFF
--- a/client/src/Exposurepedia/ExposureItemTable.tsx
+++ b/client/src/Exposurepedia/ExposureItemTable.tsx
@@ -12,6 +12,8 @@ import {
   IconButton,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { TableSortLabel } from '@material-ui/core';
+import { KeyboardArrowDown, KeyboardArrowUp } from '@material-ui/icons';
 import { makeStyles } from '@mui/styles';
 import { useNavigate } from 'react-router-dom';
 
@@ -28,6 +30,10 @@ interface TableProps {
   setCount?: React.Dispatch<React.SetStateAction<number>>;
   selectedRows?: TRow[];
   setSelectedRows?: React.Dispatch<React.SetStateAction<TRow[]>>;
+  sortColumn?: string;
+  setSortColumn?: React.Dispatch<React.SetStateAction<string>>;
+  sortDirection?: 'asc' | 'desc';
+  setSortDirection?: React.Dispatch<React.SetStateAction<'asc' | 'desc'>>;
 }
 
 interface RowProps {
@@ -202,9 +208,21 @@ function ExposureItemTable({
   setCount,
   selectedRows,
   setSelectedRows,
+  sortColumn,
+  setSortColumn,
+  sortDirection,
+  setSortDirection,
 }: TableProps) {
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
+
+  const handleSort = (columnId: string) => {
+    const isAsc = sortColumn === columnId && sortDirection === 'asc';
+    if (setSortColumn && setSortDirection) {
+      setSortColumn(columnId);
+      setSortDirection(isAsc ? 'desc' : 'asc');
+    }
+  };
 
   const handleChangePage = (event: unknown, newPage: number) => {
     setPage(newPage);
@@ -238,7 +256,13 @@ function ExposureItemTable({
                   align={column.align || 'left'}
                   style={{ minWidth: column.minWidth }}
                 >
-                  {column.label}
+                  <TableSortLabel
+                    active={sortColumn === column.id}
+                    direction={sortColumn === column.id ? sortDirection : 'asc'}
+                    onClick={() => handleSort(column.id)}
+                  >
+                    {column.label}
+                  </TableSortLabel>
                 </TableCell>
               ))}
             </TableRow>

--- a/client/src/Exposurepedia/ExposurepediaPage.tsx
+++ b/client/src/Exposurepedia/ExposurepediaPage.tsx
@@ -131,8 +131,8 @@ function Exposurepedia() {
   const [filterOptions, setFilterOptions] = useState(initFilterOptions);
   const [hierarchies, setHierarchies] = useState([]);
   const [query, setQuery] = useState('');
-  const [sortColumn, setSortColumn] = useState('Likes');
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [sortColumn, setSortColumn] = useState('likes');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const user = useAppSelector(selectUser);
   const email = user?.email?.toLowerCase();
 

--- a/client/src/Exposurepedia/ExposurepediaPage.tsx
+++ b/client/src/Exposurepedia/ExposurepediaPage.tsx
@@ -131,6 +131,8 @@ function Exposurepedia() {
   const [filterOptions, setFilterOptions] = useState(initFilterOptions);
   const [hierarchies, setHierarchies] = useState([]);
   const [query, setQuery] = useState('');
+  const [sortColumn, setSortColumn] = useState('Likes');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const user = useAppSelector(selectUser);
   const email = user?.email?.toLowerCase();
 
@@ -196,13 +198,15 @@ function Exposurepedia() {
         isLinkBroken: false,
         isApproved: true,
         query,
+        sortColumn,
+        sortDirection,
       });
       setRows(response.data);
       console.log('response data:');
       console.log(response.data);
     };
     fetchData();
-  }, [filterOptions, query]);
+  }, [filterOptions, query, sortColumn, sortDirection]);
 
   return (
     <div>
@@ -239,6 +243,10 @@ function Exposurepedia() {
               setCount={setCount}
               selectedRows={selectedRows}
               setSelectedRows={setSelectedRows}
+              sortColumn={sortColumn}
+              setSortColumn={setSortColumn}
+              sortDirection={sortDirection}
+              setSortDirection={setSortDirection}
             />
           </div>
         </Box>

--- a/server/src/controllers/exposure.controller.ts
+++ b/server/src/controllers/exposure.controller.ts
@@ -172,6 +172,8 @@ const getFilteredExposureItems = async (
     isLinkBroken,
     isApproved,
     query,
+    sortColumn,
+    sortDirection,
   } = req.body;
 
   if (
@@ -208,6 +210,8 @@ const getFilteredExposureItems = async (
       isLinkBroken,
       isApproved,
       query,
+      sortColumn,
+      sortDirection,
     );
     res.status(StatusCode.OK).json(exposureItems);
   } catch (err) {

--- a/server/src/services/exposure.service.ts
+++ b/server/src/services/exposure.service.ts
@@ -50,6 +50,8 @@ const getFilteredExposureItemsFromDB = async (
   isLinkBroken: boolean,
   isApproved: boolean,
   query: string,
+  sortColumn: string,
+  sortDirection: 'asc' | 'desc'
 ) => {
   const match: any = {};
 
@@ -175,6 +177,7 @@ const getFilteredExposureItemsFromDB = async (
           },
         ],
   )
+    .sort({ [sortColumn]: sortDirection })
     .limit(maxCount)
     .exec();
 };


### PR DESCRIPTION
Sort by title, format, likes, or date in Exposurepedia table, ascending or descending. Defaults to likes descending.

<img width="1238" alt="image" src="https://github.com/hack4impact-upenn/exposurepedia/assets/67604374/8dbbc73b-32a0-4946-9733-66e31320bc7c">
<img width="1229" alt="image" src="https://github.com/hack4impact-upenn/exposurepedia/assets/67604374/c5871967-76d0-4daf-b71d-51ca95bea033">
